### PR TITLE
feat: 可以自定义需要转换的属性名称的匹配规则

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,13 @@ import { createFilter } from '@rollup/pluginutils'
 import type { Options } from './types'
 import { transformCode } from './core'
 
-export default createUnplugin<Options>((options = {}) => {
-  const rules = options.rules
+export default createUnplugin((options?: Options) => {
+  const rules = options?.rules
+  const classNameMatcher = options?.classNameMatcher ?? 'class'
 
   const filter = createFilter(
-    options.include || [/\.[jt]sx?$/, /\.vue$/, /\.vue\?vue/],
-    options.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/],
+    options?.include || [/\.[jt]sx?$/, /\.vue$/, /\.vue\?vue/],
+    options?.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/],
   )
 
   return {
@@ -18,7 +19,7 @@ export default createUnplugin<Options>((options = {}) => {
       return filter(id)
     },
     transform(code) {
-      return transformCode(code, rules)
+      return transformCode(code, rules, classNameMatcher)
     },
   }
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { FilterPattern } from '@rollup/pluginutils'
 
+export type ClassNameMatcher = RegExp | string
 export interface Options {
   /**
    * 自定义转换规则
@@ -33,4 +34,10 @@ export interface Options {
    * @default [/\.[jt]sx?$/, /\.vue$/,  /\.vue\?vue/]
    */
   include?: FilterPattern
+
+  /**
+   * 需要转换的类名匹配规则
+   * @default "class"
+   */
+  classNameMatcher?: ClassNameMatcher
 }


### PR DESCRIPTION
有些时候需要将样式作为属性名传递给子组件，这种情况下由于该属性的样式类不会被转换，导致样式不生效。例如：

```
// ParentComponent.vue
<SomeComponent ext-class="c-#FF0000" />

// SomeComponent.vue
<view :class="extClass" />
```